### PR TITLE
Drop support for Python 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ _A logical, reasonably standardized, but flexible project structure for doing an
 
 ### Requirements to use the cookiecutter template:
 -----------
- - Python 2.7 or 3.5
+ - Python 3.6+
  - [Cookiecutter Python package](http://cookiecutter.readthedocs.org/en/latest/installation.html) >= 1.4.0: This can be installed with pip by or conda depending on how you manage your Python packages:
 
 ``` bash

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,6 +5,5 @@
     "description": "A short description of the project.",
     "open_source_license": ["MIT", "BSD-3-Clause", "No license file"],
     "s3_bucket": "[OPTIONAL] your-bucket-for-syncing-data (do not include 's3://')",
-    "aws_profile": "default",
-    "python_interpreter": ["python3", "python"]
+    "aws_profile": "default"
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,6 @@ args = {
         'project_name': 'DrivenData',
         'author_name': 'DrivenData',
         'open_source_license': 'BSD-3-Clause',
-        'python_interpreter': 'python'
         }
 
 

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -73,10 +73,6 @@ class TestCookieSetup(object):
         reqs_path = self.path / 'requirements.txt'
         assert reqs_path.exists()
         assert no_curlies(reqs_path)
-        if pytest.param.get('python_interpreter'):
-            with open(reqs_path) as fin:
-                lines = list(map(lambda x: x.strip(), fin.readlines()))
-            assert 'pathlib2' in lines
 
     def test_makefile(self):
         makefile_path = self.path / 'Makefile'

--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -8,7 +8,6 @@ PROJECT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 BUCKET = {{ cookiecutter.s3_bucket }}
 PROFILE = {{ cookiecutter.aws_profile }}
 PROJECT_NAME = {{ cookiecutter.repo_name }}
-PYTHON_INTERPRETER = {{ cookiecutter.python_interpreter }}
 
 ifeq (,$(shell which conda))
 HAS_CONDA=False
@@ -22,12 +21,12 @@ endif
 
 ## Install Python Dependencies
 requirements: test_environment
-	$(PYTHON_INTERPRETER) -m pip install -U pip setuptools wheel
-	$(PYTHON_INTERPRETER) -m pip install -r requirements.txt
+	python -m pip install -U pip setuptools wheel
+	python -m pip install -r requirements.txt
 
 ## Make Dataset
 data: requirements
-	$(PYTHON_INTERPRETER) src/data/make_dataset.py data/raw data/processed
+	python src/data/make_dataset.py data/raw data/processed
 
 ## Delete all compiled Python files
 clean:
@@ -57,24 +56,20 @@ endif
 ## Set up python interpreter environment
 create_environment:
 ifeq (True,$(HAS_CONDA))
-		@echo ">>> Detected conda, creating conda environment."
-ifeq (3,$(findstring 3,$(PYTHON_INTERPRETER)))
+	@echo ">>> Detected conda, creating conda environment."
 	conda create --name $(PROJECT_NAME) python=3
+	@echo ">>> New conda env created. Activate with:\nsource activate $(PROJECT_NAME)"
 else
-	conda create --name $(PROJECT_NAME) python=2.7
-endif
-		@echo ">>> New conda env created. Activate with:\nsource activate $(PROJECT_NAME)"
-else
-	$(PYTHON_INTERPRETER) -m pip install -q virtualenv virtualenvwrapper
+	python -m pip install -q virtualenv virtualenvwrapper
 	@echo ">>> Installing virtualenvwrapper if not already installed.\nMake sure the following lines are in shell startup file\n\
 	export WORKON_HOME=$$HOME/.virtualenvs\nexport PROJECT_HOME=$$HOME/Devel\nsource /usr/local/bin/virtualenvwrapper.sh\n"
-	@bash -c "source `which virtualenvwrapper.sh`;mkvirtualenv $(PROJECT_NAME) --python=$(PYTHON_INTERPRETER)"
+	@bash -c "source `which virtualenvwrapper.sh`;mkvirtualenv $(PROJECT_NAME) --python=python3"
 	@echo ">>> New virtualenv created. Activate with:\nworkon $(PROJECT_NAME)"
 endif
 
 ## Test python environment is setup correctly
 test_environment:
-	$(PYTHON_INTERPRETER) test_environment.py
+	python test_environment.py
 
 #################################################################################
 # PROJECT RULES                                                                 #

--- a/{{ cookiecutter.repo_name }}/requirements.txt
+++ b/{{ cookiecutter.repo_name }}/requirements.txt
@@ -8,8 +8,3 @@ coverage
 awscli
 flake8
 python-dotenv>=0.5.1
-{% if cookiecutter.python_interpreter != 'python3' %}
-
-# backwards compatibility
-pathlib2
-{% endif %}

--- a/{{ cookiecutter.repo_name }}/test_environment.py
+++ b/{{ cookiecutter.repo_name }}/test_environment.py
@@ -1,22 +1,15 @@
 import sys
 
-REQUIRED_PYTHON = "{{ cookiecutter.python_interpreter }}"
-
+REQUIRED_PYTHON_MAJOR_VERSION = 3
 
 def main():
     system_major = sys.version_info.major
-    if REQUIRED_PYTHON == "python":
-        required_major = 2
-    elif REQUIRED_PYTHON == "python3":
-        required_major = 3
-    else:
-        raise ValueError("Unrecognized python interpreter: {}".format(
-            REQUIRED_PYTHON))
-
-    if system_major != required_major:
+    if system_major != REQUIRED_PYTHON_MAJOR_VERSION:
         raise TypeError(
-            "This project requires Python {}. Found: Python {}".format(
-                required_major, sys.version))
+            "This project requires Python 3. Found: Python {}".format(
+                REQUIRED_PYTHON_MAJOR_VERSION, sys.version
+            )
+        )
     else:
         print(">>> Development environment passes all tests!")
 


### PR DESCRIPTION
Official support for Python 2 ended on Jan 1, 2020 (see
https://www.python.org/doc/sunset-python-2/ for more info).

This change does not prevent anybody from using Python 2, but
we should not be encouraging new projects to use it.